### PR TITLE
Add ConfigManager style tests

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,25 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from config.configmanager import ConfigManager
+
+def test_get_style_from_file(tmp_path):
+    cfg_path = tmp_path / "conf.json"
+    with cfg_path.open("w", encoding="utf-8") as f:
+        json.dump({"style": "Világos"}, f)
+
+    cm = ConfigManager(str(cfg_path))
+    cm.load_config()
+    assert cm.get_style() == "Világos"
+
+
+def test_get_style_default_when_missing(tmp_path):
+    cfg_path = tmp_path / "conf.json"
+    with cfg_path.open("w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    cm = ConfigManager(str(cfg_path))
+    cm.load_config()
+    assert cm.get_style() == "Sötét"

--- a/tests/test_dark_theme.py
+++ b/tests/test_dark_theme.py
@@ -1,6 +1,11 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import pytest
+
+# Skip this module entirely if PyQt5 is not installed.
+pytest.importorskip("PyQt5")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from PyQt5.QtWidgets import QApplication, QWidget
 
 from config.configmanager import ConfigManager


### PR DESCRIPTION
## Summary
- skip `test_dark_theme` if PyQt5 is not installed
- add tests for `ConfigManager.get_style`

## Testing
- `pytest -q`

------
